### PR TITLE
feat add dynamic handling for link rel and target attributes

### DIFF
--- a/packages/tools/link-tool/src/components/DefaultLinkToolRender.tsx
+++ b/packages/tools/link-tool/src/components/DefaultLinkToolRender.tsx
@@ -4,6 +4,8 @@ import { LinkToolRenderProps, Link } from '../types';
 const DEFAULT_LINK_VALUE: Link = {
   url: '',
   title: '',
+  target: '_blank',
+  rel: 'noreferrer',
 };
 
 function isUrl(string: any): boolean {

--- a/packages/tools/link-tool/src/types.ts
+++ b/packages/tools/link-tool/src/types.ts
@@ -3,6 +3,8 @@ import { YooEditor } from '@yoopta/editor';
 export type Link = {
   url: string;
   title: string;
+  rel?: string;
+  target?: string;
 };
 
 export type LinkToolRenderProps = {


### PR DESCRIPTION
## Description

This pull request introduces the ability to dynamically update the `target` and `rel` attributes of a link within the `LinkTool`. This enhancement addresses a use case where these attributes need to be customizable for different links, allowing flexibility and control over link behavior. The current implementation allows passing attributes like target and rel through the onSave callback, providing the ability to customize each link based on specific needs.

Fixes #159 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
