### PR TITLE
fix: make it possible to embed x.com post with the embed plugin

### DIFF
--- a/packages/plugins/embed/src/utils/providers.ts
+++ b/packages/plugins/embed/src/utils/providers.ts
@@ -31,7 +31,7 @@ export function getProvider(url: string): EmbedProviderTypes | null {
     return 'vimeo';
   } else if (url.includes('dailymotion.com') || url.includes('dai.ly')) {
     return 'dailymotion';
-  } else if (url.includes('twitter') || url.includes('x.com')) {
+  } else if (url.includes('twitter') || url.includes('https://x.com')) {
     return 'twitter';
   } else if (url.includes('figma')) {
     return 'figma';

--- a/packages/plugins/embed/src/utils/providers.ts
+++ b/packages/plugins/embed/src/utils/providers.ts
@@ -31,7 +31,7 @@ export function getProvider(url: string): EmbedProviderTypes | null {
     return 'vimeo';
   } else if (url.includes('dailymotion.com') || url.includes('dai.ly')) {
     return 'dailymotion';
-  } else if (url.includes('twitter')) {
+  } else if (url.includes('twitter') || url.includes('x.com')) {
     return 'twitter';
   } else if (url.includes('figma')) {
     return 'figma';


### PR DESCRIPTION
## Description

Twitter / X changed its domain from twitter.com to x.com recently, so when users click the "Copy link" button, they will get a "x.com" link, which the embed plugin can't handle.
This PR checks for x.com links and treat them as twitter. 

Fixes # (issue)
https://github.com/Darginec05/Yoopta-Editor/issues/165

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
