### PR TITLE
fix: action menu don't open on click

### DIFF
--- a/packages/core/editor/src/components/Editor/dnd.ts
+++ b/packages/core/editor/src/components/Editor/dnd.ts
@@ -7,8 +7,7 @@ export const useYooptaDragDrop = ({ editor }: { editor: YooEditor }) => {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        delay: 100,
-        tolerance: 0,
+        distance: 20,
       },
     }),
     useSensor(KeyboardSensor, {


### PR DESCRIPTION
## Description

I changed the way the drag button behaves with the drag behavior of @dnd-kit.
Now, clicking the drag button will open the action menu without altering the drag functionality.

Fixes #171 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
