### PR TITLE
fix: min-width: 400px applied to the .yoopta-editor 

### DIFF
--- a/packages/core/editor/src/styles.css
+++ b/packages/core/editor/src/styles.css
@@ -56,7 +56,6 @@ pre {
 }
 
 .yoopta-editor {
-  min-width: 400px;
   height: auto;
 }
 


### PR DESCRIPTION
## Description

There is a min-width: 400px applied to the .yoopta-editor class, which prevents the editor from being resized below 400px in width. This creates an issue when trying to embed the Yoopta-Editor in a container that is less than 400px wide.


Fixes #177 

## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
