### PR TITLE
Fix: Positioning bug of Action Menu

### DIFF
--- a/packages/tools/action-menu/src/components/ActionMenuList.tsx
+++ b/packages/tools/action-menu/src/components/ActionMenuList.tsx
@@ -47,7 +47,7 @@ const ActionMenuList = ({ items, render }: ActionMenuToolProps) => {
     placement: 'bottom-start',
     open: isMenuOpen,
     onOpenChange: setIsMenuOpen,
-    middleware: [inline(), flip(), shift(), offset(10)],
+    middleware: [flip(), shift(), offset(10)],
     whileElementsMounted: autoUpdate,
   });
 


### PR DESCRIPTION
## Description

Fixes issue #327 

The bug was caused by the `inline()` reference. Removing it fixed the action menu. I've attached videos showing the issue before and after the fix.


### Current:
https://github.com/user-attachments/assets/beb24ca2-2fee-4f66-852f-0b93fe0f6887

### After fix:
https://github.com/user-attachments/assets/24a41060-f113-4ecf-b030-eda6df3268a7


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
