### PR TITLE
Allow pasting image from clipboard

### DIFF
--- a/packages/core/editor/src/parsers/getClipboardImage.ts
+++ b/packages/core/editor/src/parsers/getClipboardImage.ts
@@ -1,0 +1,41 @@
+import { generateId } from '../utils/generateId';
+import { YooEditor, YooptaBlockData } from '../editor/types';
+
+const buildBlockData = (imageURL: string) => {
+  const blockData = {
+    id: generateId(),
+    type: 'Image',
+    value: [
+      {
+        id: generateId(),
+        type: 'image',
+        children: [{ text: '' }],
+        props: {
+          nodeType: 'void',
+          src: imageURL,
+          alt: 'pasted image',
+          srcSet: null,
+          fit: 'contain',
+        },
+      },
+    ],
+    meta: {
+      order: 0,
+      depth: 0,
+      align: 'left',
+    },
+  };
+  return blockData as YooptaBlockData;
+};
+
+export const pasteClipboardImage = (editor: YooEditor, image: DataTransferItem) => {
+  const blob = image.getAsFile();
+  if (!blob) return;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    if (!e.target) return;
+    const blockData = buildBlockData(e.target.result as string);
+    editor.insertBlock(blockData, { at: editor.selection, focus: true });
+  };
+  reader.readAsDataURL(blob);
+};

--- a/packages/core/editor/src/plugins/SlateEditorComponent.tsx
+++ b/packages/core/editor/src/plugins/SlateEditorComponent.tsx
@@ -11,6 +11,7 @@ import { TextLeaf } from '../components/TextLeaf/TextLeaf';
 
 import { IS_FOCUSED_EDITOR } from '../utils/weakMaps';
 import { deserializeHTML } from '../parsers/deserializeHTML';
+import { pasteClipboardImage } from '../parsers/getClipboardImage';
 import { useEventHandlers, useSlateEditor } from './hooks';
 import { SlateElement } from '../editor/types';
 
@@ -154,9 +155,9 @@ const SlateEditorComponent = <TElementMap extends Record<string, SlateElement>, 
 
       const data = event.clipboardData;
       const html = data.getData('text/html');
+      const clipboardItem = data.items[0];
 
       const parsedHTML = new DOMParser().parseFromString(html, 'text/html');
-
       if (parsedHTML.body.childNodes.length > 0) {
         const blocks = deserializeHTML(editor, parsedHTML.body);
 
@@ -166,6 +167,11 @@ const SlateEditorComponent = <TElementMap extends Record<string, SlateElement>, 
           editor.insertBlocks(blocks, { at: editor.selection, focus: true });
           return;
         }
+      }
+      const isImageInClipboard = clipboardItem?.type?.startsWith('image/');
+      if (isImageInClipboard) {
+        event.preventDefault();
+        pasteClipboardImage(editor, clipboardItem);
       }
     },
     [eventHandlers.onPaste, editor.readOnly],


### PR DESCRIPTION
## Description

The editor currently only supports copying and pasting images from the internet. It cannot paste images from the local clipboard, like screenshots. This PR adds support for pasting images directly from the clipboard.

https://github.com/user-attachments/assets/c18f1470-44a4-4125-82ee-3c043d531d09


Related issue #320

## Type of change

Please tick the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
