### PR TITLE
[Fix] Markdown shortcut removes existing block

### DIFF
--- a/packages/core/editor/src/extensions/shortcuts.tsx
+++ b/packages/core/editor/src/extensions/shortcuts.tsx
@@ -38,6 +38,7 @@ export const withShortcuts = (editor: YooEditor, slate: SlateEditor) => {
       if (hasMatchedBlock && !matchedBlock.isActive()) {
         Transforms.select(slate, range);
         Transforms.delete(slate);
+        editor.blocks[matchedBlock.type].toggle({ focus: true });
         Blocks.createBlock(editor, matchedBlock.type, { deleteText: false, focus: true });
         return;
       }


### PR DESCRIPTION
## Related issues
 - #333 
 - #206 
 
## Description

When using markdown symbols (e.g., #, - ) to convert an existing text block into a heading or bullet list, the entire text block gets removed, leaving a blank block with the new markdown format.

Attaching a video of the fix

https://github.com/user-attachments/assets/eef5b112-e37d-4691-a8ef-2daa2f763283


## Type of change

Please tick the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
