### PR TITLE
Add email export, implement export for paragraph and headings

### DIFF
--- a/packages/core/editor/src/contexts/YooptaContext/YooptaContext.tsx
+++ b/packages/core/editor/src/contexts/YooptaContext/YooptaContext.tsx
@@ -56,6 +56,7 @@ const DEFAULT_HANDLERS: YooptaEditorContext = {
     getHTML: () => '',
     getMarkdown: () => '',
     getPlainText: () => '',
+    getEmail: () => '',
 
     refElement: null,
   },

--- a/packages/core/editor/src/editor/index.tsx
+++ b/packages/core/editor/src/editor/index.tsx
@@ -24,6 +24,7 @@ import { getMarkdown } from '../parsers/getMarkdown';
 import { getPlainText } from '../parsers/getPlainText';
 import { isEmpty } from './core/isEmpty';
 import { Plugin } from '../plugins/types';
+import { getEmail } from '../parsers/getEmail';
 
 export function createYooptaEditor(): YooEditor {
   const editor: YooEditor = {
@@ -70,6 +71,7 @@ export function createYooptaEditor(): YooEditor {
     getHTML: (content: YooptaContentValue) => getHTML(editor, content),
     getMarkdown: (content: YooptaContentValue) => getMarkdown(editor, content),
     getPlainText: (content: YooptaContentValue) => getPlainText(editor, content),
+    getEmail: (content: YooptaContentValue) => getEmail(editor, content),
 
     refElement: null,
   };

--- a/packages/core/editor/src/editor/types.ts
+++ b/packages/core/editor/src/editor/types.ts
@@ -122,6 +122,7 @@ export type YooEditor = {
   getHTML: (content: YooptaContentValue) => string;
   getMarkdown: (content: YooptaContentValue) => string;
   getPlainText: (content: YooptaContentValue) => string;
+  getEmail: (content: YooptaContentValue) => string;
 
   // ref to editor element
   refElement: HTMLElement | null;

--- a/packages/core/editor/src/parsers/getEmail.ts
+++ b/packages/core/editor/src/parsers/getEmail.ts
@@ -60,13 +60,23 @@ export function getEmail(editor: YooEditor, content: YooptaContentValue): string
     return '';
   });
 
-  return `<table id="yoopta-clipboard" data-editor-id="${editor.id}">
-    <tbody>
-      <tr>
-        <td>
+  return `
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+      <html dir="ltr" lang="en">
+
+        <head>
+          <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+          <meta name="x-apple-disable-message-reformatting" />
+
+          <!-- support Outlook -->
+          <style type="text/css">
+            .ExternalClass {width: 100%;}
+          </style>
+        </head>
+
+        <body style="margin:0;padding: 0;" id="yoopta-clipboard" data-editor-id="${editor.id}">
           ${email.join('')}
-        </td>
-      </tr>
-    </tbody>
-  </table>`;
+        </body>
+      </html>
+  `;
 }

--- a/packages/core/editor/src/parsers/getEmail.ts
+++ b/packages/core/editor/src/parsers/getEmail.ts
@@ -1,0 +1,72 @@
+import { SlateElement, YooEditor, YooptaContentValue } from '../editor/types';
+import { getPluginByInlineElement } from '../utils/blockElements';
+
+const MARKS_NODE_NAME_MATCHERS_MAP = {
+  underline: { type: 'underline', tag: 'U' },
+  strike: { type: 'strike', tag: 'S' },
+  code: { type: 'code', tag: 'CODE' },
+  italic: { type: 'italic', tag: 'I' },
+  bold: { type: 'bold', tag: 'B' },
+};
+
+function serializeChildren(children, plugins) {
+  return children
+    .map((child) => {
+      let innerHtml = '';
+
+      if (child.text) {
+        innerHtml = Object.keys(MARKS_NODE_NAME_MATCHERS_MAP).reduce((acc, mark) => {
+          if (child[mark]) {
+            return `<${MARKS_NODE_NAME_MATCHERS_MAP[mark].tag}>${acc}</${MARKS_NODE_NAME_MATCHERS_MAP[mark].tag}>`;
+          }
+          return acc;
+        }, child.text);
+
+        return innerHtml;
+      } else if (child.type) {
+        const childPlugin = getPluginByInlineElement(plugins, child.type);
+
+        if (childPlugin && childPlugin.parsers?.html?.serialize) {
+          // We don't pass block meta data to this because it's inline element inside block
+          innerHtml = childPlugin.parsers.html.serialize(child, serializeChildren(child.children, plugins));
+          return innerHtml;
+        }
+      }
+
+      return innerHtml;
+    })
+    .join('');
+}
+
+export function getEmail(editor: YooEditor, content: YooptaContentValue): string {
+  const blocks = Object.values(content)
+    .filter((item) => {
+      if (Array.isArray(editor.selectedBlocks) && editor.selectedBlocks.length > 0) {
+        return editor.selectedBlocks?.includes(item.meta.order);
+      }
+
+      return true;
+    })
+    .sort((a, b) => a.meta.order - b.meta.order);
+
+  const email = blocks.map((blockData) => {
+    const plugin = editor.plugins[blockData.type];
+
+    if (plugin && plugin.parsers?.email?.serialize) {
+      const content = serializeChildren((blockData.value[0] as SlateElement).children, editor.plugins);
+      return plugin.parsers.email.serialize(blockData.value[0] as SlateElement, content, blockData.meta);
+    }
+
+    return '';
+  });
+
+  return `<table id="yoopta-clipboard" data-editor-id="${editor.id}">
+    <tbody>
+      <tr>
+        <td>
+          ${email.join('')}
+        </td>
+      </tr>
+    </tbody>
+  </table>`;
+}

--- a/packages/core/editor/src/plugins/types.ts
+++ b/packages/core/editor/src/plugins/types.ts
@@ -96,7 +96,7 @@ export type PluginParsers = {
   serialize?: PluginserializeParser;
 };
 
-export type PluginParserTypes = 'html' | 'markdown';
+export type PluginParserTypes = 'html' | 'markdown' | 'email';
 export type PluginParserValues = 'deserialize' | 'serialize';
 
 export type PluginserializeParser = (

--- a/packages/development/src/components/FixedToolbar/FixedToolbar.tsx
+++ b/packages/development/src/components/FixedToolbar/FixedToolbar.tsx
@@ -140,6 +140,16 @@ export const FixedToolbar = ({ editor }: Props) => {
         >
           Update Callout theme
         </button>
+        <button
+          type="button"
+          onClick={() => {
+            const emailContent = editor.getEmail(editor.getEditorValue());
+            console.log(emailContent);
+          }}
+          className="p-2 text-xs shadow-md hover:bg-[#64748b] hover:text-[#fff]"
+        >
+          Get email content
+        </button>
       </div>
     </div>
   );

--- a/packages/plugins/blockquote/src/plugin/index.tsx
+++ b/packages/plugins/blockquote/src/plugin/index.tsx
@@ -1,4 +1,4 @@
-import { serializeTextNodesIntoMarkdown, YooptaPlugin } from '@yoopta/editor';
+import { serializeTextNodes, serializeTextNodesIntoMarkdown, YooptaPlugin } from '@yoopta/editor';
 import { BlockquoteCommands } from '../commands';
 import { BlockquoteElement } from '../types';
 import { BlockquoteRender } from '../ui/Blockquote';
@@ -25,12 +25,31 @@ const Blockquote = new YooptaPlugin<Record<'blockquote', BlockquoteElement>>({
       },
       serialize: (element, text, blockMeta) => {
         const { align = 'left', depth = 0 } = blockMeta || {};
-        return `<blockquote data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}; border-left: 3px solid; color: #292929; padding: 2px 14px; margin-top: 8px;">${text}</blockquote>`;
+        return `<blockquote data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}; border-left: 3px solid; color: #292929; padding: 2px 14px; margin-top: 8px;">${serializeTextNodes(
+          element.children,
+        )}</blockquote>`;
       },
     },
     markdown: {
       serialize: (element, text) => {
         return `> ${serializeTextNodesIntoMarkdown(element.children)}`;
+      },
+    },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+        return `
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <blockquote data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}; border-left: 3px solid; color: #292929; padding: 2px 14px; margin-top: 8px;">${serializeTextNodes(
+          element.children,
+        )}</blockquote>
+              </td>
+            </tr>
+          </tbody>
+        </table>`;
       },
     },
   },

--- a/packages/plugins/callout/src/plugin/index.tsx
+++ b/packages/plugins/callout/src/plugin/index.tsx
@@ -66,6 +66,29 @@ const Callout = new YooptaPlugin<CalloutElementMap>({
         return `> ${serializeTextNodesIntoMarkdown(element.children)}`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const theme: CSSProperties = CALLOUT_THEME_STYLES[element.props?.theme || 'default'];
+        const { align = 'left', depth = 0 } = blockMeta || {};
+
+        return `<table>
+        <tbody>
+          <tr>
+            <td>
+              <div data-theme="${
+                element.props?.theme || 'default'
+              }" data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}; padding: .5rem .5rem .5rem 1rem; margin-top: .5rem; border-radius: .375rem; color: ${
+          theme.color
+        }; border-left: ${theme.borderLeft || 0}; background-color: ${theme.backgroundColor}">${serializeTextNodes(
+          element.children,
+        )}
+            </div>
+          </td>
+          </tr>
+      </tbody>
+      </table>`;
+      },
+    },
   },
 });
 

--- a/packages/plugins/code/src/plugin/index.tsx
+++ b/packages/plugins/code/src/plugin/index.tsx
@@ -70,6 +70,25 @@ const Code = new YooptaPlugin<CodeElementMap, CodePluginBlockOptions>({
         return `\`\`\`${element.props.language || 'javascript'}\n${text}\n\`\`\``;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+        const justify = ALIGNS_TO_JUSTIFY[align] || 'left';
+        const escapedText = escapeHTML(text);
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <pre data-theme="${element.props.theme}" data-language="${element.props.language}" data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; display: flex; width: 100%; justify-content: "${justify}"; background-color: #263238; color: #fff; padding: 20px 24px; white-space: pre-line;"><code>${escapedText}</code></pre>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `.toString();
+      },
+    },
   },
 });
 

--- a/packages/plugins/divider/src/plugin/index.tsx
+++ b/packages/plugins/divider/src/plugin/index.tsx
@@ -53,6 +53,21 @@ const Divider = new YooptaPlugin<DividerElementMap>({
         return '---\n';
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { theme = 'solid', color = '#EFEFEE' } = element.props || {};
+        return `
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <hr data-meta-theme="${theme}" data-meta-color="${color}" style="background-color: #8383e0; height: 1.2px" />
+              </td>
+            </tr>
+          </tbody>
+        </table>`;
+      },
+    },
   },
   commands: DividerCommands,
   events: {

--- a/packages/plugins/file/src/plugin/index.tsx
+++ b/packages/plugins/file/src/plugin/index.tsx
@@ -83,6 +83,30 @@ const File = new YooptaPlugin<FileElementMap, FilePluginOptions>({
         return `[${element.props.name}](${element.props.src})`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+        const justify = ALIGNS_TO_JUSTIFY[align] || 'left';
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <div style="margin-left: ${depth}px; display: flex; width: 100%; justify-content: ${justify}"><a data-meta-align="${align}" data-meta-depth="${depth}" href="${
+          element.props.src
+        }" data-size="${element.props.size}" download="${
+          element.props.name
+        }" target="_blank" rel="noopener noreferrer">${
+          element.props.format ? `${element.props.name}.${element.props.format}` : `${element.props.name}`
+        }</a></div>
+                </td>
+              </tr>
+            </tbody>
+          </table>            
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/headings/src/plugin/HeadingOne.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingOne.tsx
@@ -48,7 +48,9 @@ const HeadingOne = new YooptaPlugin<Record<'heading-one', HeadingOneElement>>({
       serialize: (element, text, blockMeta) => {
         const { depth = 0, align = 'left' } = blockMeta || {};
 
-        return `<h1 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${text}</h1>`;
+        return `<h1 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${serializeTextNodes(
+          element.children,
+        )}</h1>`;
       },
     },
     markdown: {
@@ -57,14 +59,16 @@ const HeadingOne = new YooptaPlugin<Record<'heading-one', HeadingOneElement>>({
       },
     },
     email: {
-      serialize: (element, text) => {
+      serialize: (element, text, blockMeta) => {
+        const { depth = 0, align = 'left' } = blockMeta || {};
+
         return `<table>
         <tbody>
           <tr>
             <td style="padding: 10px 0;">
-            <h1>
-              ${serializeTextNodes(element.children)}
-            </h1>
+              <h1 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
+                ${serializeTextNodes(element.children)}
+              </h1>
             </td>
           </tr>
         </tbody>

--- a/packages/plugins/headings/src/plugin/HeadingOne.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingOne.tsx
@@ -1,4 +1,9 @@
-import { YooptaPlugin, PluginElementRenderProps, serializeTextNodesIntoMarkdown } from '@yoopta/editor';
+import {
+  YooptaPlugin,
+  PluginElementRenderProps,
+  serializeTextNodesIntoMarkdown,
+  serializeTextNodes,
+} from '@yoopta/editor';
 import { HeadingOneCommands } from '../commands';
 import { HeadingOneElement } from '../types';
 
@@ -49,6 +54,21 @@ const HeadingOne = new YooptaPlugin<Record<'heading-one', HeadingOneElement>>({
     markdown: {
       serialize: (element, text) => {
         return `# ${serializeTextNodesIntoMarkdown(element.children)}\n`;
+      },
+    },
+    email: {
+      serialize: (element, text) => {
+        return `<table>
+        <tbody>
+          <tr>
+            <td style="padding: 10px 0;">
+            <h1>
+              ${serializeTextNodes(element.children)}
+            </h1>
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
       },
     },
   },

--- a/packages/plugins/headings/src/plugin/HeadingOne.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingOne.tsx
@@ -65,7 +65,7 @@ const HeadingOne = new YooptaPlugin<Record<'heading-one', HeadingOneElement>>({
         return `<table>
         <tbody>
           <tr>
-            <td style="padding: 10px 0;">
+            <td>
               <h1 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
                 ${serializeTextNodes(element.children)}
               </h1>

--- a/packages/plugins/headings/src/plugin/HeadingThree.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingThree.tsx
@@ -1,4 +1,9 @@
-import { PluginElementRenderProps, serializeTextNodesIntoMarkdown, YooptaPlugin } from '@yoopta/editor';
+import {
+  PluginElementRenderProps,
+  serializeTextNodes,
+  serializeTextNodesIntoMarkdown,
+  YooptaPlugin,
+} from '@yoopta/editor';
 import { HeadingThreeCommands } from '../commands';
 import { HeadingThreeElement } from '../types';
 
@@ -55,6 +60,21 @@ const HeadingThree = new YooptaPlugin<Record<'heading-three', HeadingThreeElemen
     markdown: {
       serialize: (element, text) => {
         return `### ${serializeTextNodesIntoMarkdown(element.children)}\n`;
+      },
+    },
+    email: {
+      serialize: (element, text) => {
+        return `<table>
+        <tbody>
+          <tr>
+            <td style="padding: 10px 0;">
+            <h3>
+              ${serializeTextNodes(element.children)}
+            </h3>
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
       },
     },
   },

--- a/packages/plugins/headings/src/plugin/HeadingThree.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingThree.tsx
@@ -71,7 +71,7 @@ const HeadingThree = new YooptaPlugin<Record<'heading-three', HeadingThreeElemen
         return `<table>
         <tbody>
           <tr>
-            <td style="padding: 10px 0;">
+            <td>
               <h3 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
                 ${serializeTextNodes(element.children)}
               </h3>

--- a/packages/plugins/headings/src/plugin/HeadingThree.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingThree.tsx
@@ -54,7 +54,9 @@ const HeadingThree = new YooptaPlugin<Record<'heading-three', HeadingThreeElemen
       serialize: (element, text, blockMeta) => {
         const { depth = 0, align = 'left' } = blockMeta || {};
 
-        return `<h3 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${text}</h3>`;
+        return `<h3 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${serializeTextNodes(
+          element.children,
+        )}</h3>`;
       },
     },
     markdown: {
@@ -63,14 +65,16 @@ const HeadingThree = new YooptaPlugin<Record<'heading-three', HeadingThreeElemen
       },
     },
     email: {
-      serialize: (element, text) => {
+      serialize: (element, text, blockMeta) => {
+        const { depth = 0, align = 'left' } = blockMeta || {};
+
         return `<table>
         <tbody>
           <tr>
             <td style="padding: 10px 0;">
-            <h3>
-              ${serializeTextNodes(element.children)}
-            </h3>
+              <h3 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
+                ${serializeTextNodes(element.children)}
+              </h3>
             </td>
           </tr>
         </tbody>

--- a/packages/plugins/headings/src/plugin/HeadingTwo.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingTwo.tsx
@@ -48,7 +48,9 @@ const HeadingTwo = new YooptaPlugin<Record<'heading-two', HeadingTwoElement>>({
       serialize: (element, text, blockMeta) => {
         const { depth = 0, align = 'left' } = blockMeta || {};
 
-        return `<h2 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${text}</h2>`;
+        return `<h2 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${serializeTextNodes(
+          element.children,
+        )}</h2>`;
       },
     },
     markdown: {
@@ -57,14 +59,16 @@ const HeadingTwo = new YooptaPlugin<Record<'heading-two', HeadingTwoElement>>({
       },
     },
     email: {
-      serialize: (element, text) => {
+      serialize: (element, text, blockMeta) => {
+        const { depth = 0, align = 'left' } = blockMeta || {};
+
         return `<table>
         <tbody>
           <tr>
             <td style="padding: 10px 0;">
-            <h2>
-              ${serializeTextNodes(element.children)}
-            </h2>
+              <h2 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
+                ${serializeTextNodes(element.children)}
+              </h2>
             </td>
           </tr>
         </tbody>

--- a/packages/plugins/headings/src/plugin/HeadingTwo.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingTwo.tsx
@@ -65,7 +65,7 @@ const HeadingTwo = new YooptaPlugin<Record<'heading-two', HeadingTwoElement>>({
         return `<table>
         <tbody>
           <tr>
-            <td style="padding: 10px 0;">
+            <td>
               <h2 data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
                 ${serializeTextNodes(element.children)}
               </h2>

--- a/packages/plugins/headings/src/plugin/HeadingTwo.tsx
+++ b/packages/plugins/headings/src/plugin/HeadingTwo.tsx
@@ -1,4 +1,9 @@
-import { PluginElementRenderProps, serializeTextNodesIntoMarkdown, YooptaPlugin } from '@yoopta/editor';
+import {
+  PluginElementRenderProps,
+  serializeTextNodes,
+  serializeTextNodesIntoMarkdown,
+  YooptaPlugin,
+} from '@yoopta/editor';
 import { HeadingTwoCommands } from '../commands';
 import { HeadingTwoElement } from '../types';
 
@@ -49,6 +54,21 @@ const HeadingTwo = new YooptaPlugin<Record<'heading-two', HeadingTwoElement>>({
     markdown: {
       serialize: (element, text) => {
         return `## ${serializeTextNodesIntoMarkdown(element.children)}\n`;
+      },
+    },
+    email: {
+      serialize: (element, text) => {
+        return `<table>
+        <tbody>
+          <tr>
+            <td style="padding: 10px 0;">
+            <h2>
+              ${serializeTextNodes(element.children)}
+            </h2>
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
       },
     },
   },

--- a/packages/plugins/image/src/plugin/index.tsx
+++ b/packages/plugins/image/src/plugin/index.tsx
@@ -79,6 +79,26 @@ const Image = new YooptaPlugin<ImageElementMap, ImagePluginOptions>({
         return `![${element.props.alt}](${element.props.src})\n`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'center', depth = 0 } = blockMeta || {};
+        const justify = ALIGNS_TO_JUSTIFY[align] || 'center';
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <div style="margin-left: ${depth}px; display: flex; width: 100%; justify-content: "${justify}"">
+                    <img data-meta-align="${align}" data-meta-depth="${depth}" src="${element.props.src}" alt="${element.props.alt}" width="${element.props.sizes.width}" height="${element.props.sizes.height}" objectFit="${element.props.fit}"></img>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/link/src/plugin/index.tsx
+++ b/packages/plugins/link/src/plugin/index.tsx
@@ -60,6 +60,22 @@ const Link = new YooptaPlugin<LinkElementMap>({
         },
       },
     },
+    email: {
+      serialize: (element, text) => {
+        const { url, target, rel, title } = element.props;
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <a href="${url}" target="${target}" rel="${rel}">${serializeTextNodes(element.children)}</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/lists/src/plugin/BulletedList.tsx
+++ b/packages/plugins/lists/src/plugin/BulletedList.tsx
@@ -81,6 +81,25 @@ const BulletedList = new YooptaPlugin<Pick<ListElementMap, 'bulleted-list'>>({
         return `- ${serializeTextNodesIntoMarkdown(element.children)}`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <ul data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}"><li>${serializeTextNodes(
+          element.children,
+        )}</li></ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/lists/src/plugin/NumberedList.tsx
+++ b/packages/plugins/lists/src/plugin/NumberedList.tsx
@@ -84,6 +84,25 @@ const NumberedList = new YooptaPlugin<Pick<ListElementMap, 'numbered-list'>>({
         return `- ${serializeTextNodesIntoMarkdown(element.children)}`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <ol data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}"><li>${serializeTextNodes(
+          element.children,
+        )}</li></ol>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/lists/src/plugin/TodoList.tsx
+++ b/packages/plugins/lists/src/plugin/TodoList.tsx
@@ -87,6 +87,25 @@ const TodoList = new YooptaPlugin<Pick<ListElementMap, 'todo-list'>>({
         return `- ${element.props.checked ? '[x]' : '[ ]'} ${serializeTextNodesIntoMarkdown(element.children)}`;
       },
     },
+    email: {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+
+        return `
+          <table>
+            <tbody>
+              <tr>
+                <td>
+                  <ul data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}"><li>[${
+          element.props.checked ? 'x' : ' '
+        }] ${serializeTextNodes(element.children)}</li></ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        `;
+      },
+    },
   },
 });
 

--- a/packages/plugins/paragraph/src/plugin/index.tsx
+++ b/packages/plugins/paragraph/src/plugin/index.tsx
@@ -42,7 +42,7 @@ const Paragraph = new YooptaPlugin<ParagraphElementMap>({
         return `<table>
         <tbody>
           <tr>
-            <td style="padding: 10px 0;">
+            <td>
               <p data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
                 ${serializeTextNodes(element.children)}
               </p>

--- a/packages/plugins/paragraph/src/plugin/index.tsx
+++ b/packages/plugins/paragraph/src/plugin/index.tsx
@@ -36,14 +36,16 @@ const Paragraph = new YooptaPlugin<ParagraphElementMap>({
       },
     },
     email: {
-      serialize: (element, text) => {
+      serialize: (element, text, blockMeta) => {
+        const { align = 'left', depth = 0 } = blockMeta || {};
+
         return `<table>
         <tbody>
           <tr>
             <td style="padding: 10px 0;">
-            <p>
-              ${serializeTextNodes(element.children)}
-            </p>
+              <p data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${serializeTextNodes(
+          element.children,
+        )}</p>
             </td>
           </tr>
         </tbody>

--- a/packages/plugins/paragraph/src/plugin/index.tsx
+++ b/packages/plugins/paragraph/src/plugin/index.tsx
@@ -43,9 +43,9 @@ const Paragraph = new YooptaPlugin<ParagraphElementMap>({
         <tbody>
           <tr>
             <td style="padding: 10px 0;">
-              <p data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">${serializeTextNodes(
-          element.children,
-        )}</p>
+              <p data-meta-align="${align}" data-meta-depth="${depth}" style="margin-left: ${depth}px; text-align: ${align}">
+                ${serializeTextNodes(element.children)}
+              </p>
             </td>
           </tr>
         </tbody>

--- a/packages/plugins/paragraph/src/plugin/index.tsx
+++ b/packages/plugins/paragraph/src/plugin/index.tsx
@@ -35,6 +35,21 @@ const Paragraph = new YooptaPlugin<ParagraphElementMap>({
         return `${serializeTextNodesIntoMarkdown(element.children)}\n`;
       },
     },
+    email: {
+      serialize: (element, text) => {
+        return `<table>
+        <tbody>
+          <tr>
+            <td style="padding: 10px 0;">
+            <p>
+              ${serializeTextNodes(element.children)}
+            </p>
+            </td>
+          </tr>
+        </tbody>
+      </table>`;
+      },
+    },
   },
   commands: ParagraphCommands,
 });


### PR DESCRIPTION
## Description

Allow to get email html from current editor instance and  content.

Fixes # (issue)

## Type of change

Please tick the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
