### PR TITLE
Broken repo link in packages

### DIFF
--- a/packages/core/exports/package.json
+++ b/packages/core/exports/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Serialize/deserialize exports in different formats for Yoopta-Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "start": "rollup --config rollup.config.js --watch --bundleConfigAsCjs --environment NODE_ENV:development",
@@ -31,7 +31,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "marked": "^13.0.0"

--- a/packages/core/starter-kit/package.json
+++ b/packages/core/starter-kit/package.json
@@ -3,7 +3,7 @@
   "version": "4.7.1-alpha.4",
   "description": "StarterKit for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": true,
   "main": "dist/index.js",
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-starter-kit.test.js",
@@ -55,7 +55,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/core/yoopta-chatGPT-assistant/package.json
+++ b/packages/core/yoopta-chatGPT-assistant/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Chat GPT Assistant tool for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": true,
   "main": "dist/index.js",
@@ -23,13 +23,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-blockquote.test.js"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "ai": "^2.1.3",

--- a/packages/core/yoopta-renderer/package.json
+++ b/packages/core/yoopta-renderer/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Simple Yoopta Renderer [IN PROGRESS]",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": true,
   "main": "dist/index.js",
@@ -23,13 +23,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-code.test.js"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "lodash.uniqwith": "^4.5.0"

--- a/packages/marks/package.json
+++ b/packages/marks/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Marks for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "start": "rollup --config rollup.config.js --watch --bundleConfigAsCjs --environment NODE_ENV:development",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/accordion/package.json
+++ b/packages/plugins/accordion/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Accordion plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-accordion.test.js",
@@ -35,7 +35,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/blockquote/package.json
+++ b/packages/plugins/blockquote/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Blockquote plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-blockquote.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/callout/package.json
+++ b/packages/plugins/callout/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Callout plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-callout.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/code/package.json
+++ b/packages/plugins/code/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Code plugin with syntax highlighting for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-code.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@codemirror/lang-angular": "^0.1.3",

--- a/packages/plugins/divider/package.json
+++ b/packages/plugins/divider/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Divider plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/@yoopta/divider.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/embed/package.json
+++ b/packages/plugins/embed/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Embed plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-embed.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",

--- a/packages/plugins/file/package.json
+++ b/packages/plugins/file/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "File plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-file.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",

--- a/packages/plugins/headings/package.json
+++ b/packages/plugins/headings/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Headings plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/@yoopta/paragraph.test.js",
@@ -37,7 +37,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/image/package.json
+++ b/packages/plugins/image/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Image plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-image.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",

--- a/packages/plugins/link/package.json
+++ b/packages/plugins/link/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Link plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-link.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "lucide-react": "^0.379.0"

--- a/packages/plugins/lists/package.json
+++ b/packages/plugins/lists/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Lists plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-lists.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/mention/package.json
+++ b/packages/plugins/mention/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "Mention plugin for Yoopta Editor [IN PROGRESS]",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": true,
   "main": "dist/index.js",
@@ -23,13 +23,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-mention.test.js",
     "start": "rollup --config rollup.config.js --watch --bundleConfigAsCjs --environment NODE_ENV:development"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   }
 }

--- a/packages/plugins/paragraph/package.json
+++ b/packages/plugins/paragraph/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Paragraph plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/@yoopta/paragraph.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/plugins/table/package.json
+++ b/packages/plugins/table/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Table plugin for Yoopta Editor [IN PROGRESS]",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-table.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.22",

--- a/packages/plugins/video/package.json
+++ b/packages/plugins/video/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Video plugin for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-video.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",

--- a/packages/tools/action-menu/package.json
+++ b/packages/tools/action-menu/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "ActionMenuList tool for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-action-menu-list.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",

--- a/packages/tools/link-tool/package.json
+++ b/packages/tools/link-tool/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Link tool for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/yoopta-action-menu-list.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "gitHead": "12d8460dfe0ead89ee1d6f3f2f1fc68239e93d4c"
 }

--- a/packages/tools/toolbar/package.json
+++ b/packages/tools/toolbar/package.json
@@ -3,7 +3,7 @@
   "version": "4.8.4",
   "description": "Toolbar tool for Yoopta Editor",
   "author": "Darginec05 <devopsbanda@gmail.com>",
-  "homepage": "https://github.com/Darginec05/Editor-Yoopta#readme",
+  "homepage": "https://github.com/Darginec05/Yoopta-Editor#readme",
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Darginec05/Editor-Yoopta.git"
+    "url": "git+https://github.com/Darginec05/Yoopta-Editor.git"
   },
   "scripts": {
     "test": "node ./__tests__/@yoopta/paragraph.test.js",
@@ -32,7 +32,7 @@
     "build": "rollup --config rollup.config.js --bundleConfigAsCjs --environment NODE_ENV:production"
   },
   "bugs": {
-    "url": "https://github.com/Darginec05/Editor-Yoopta/issues"
+    "url": "https://github.com/Darginec05/Yoopta-Editor/issues"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.9",


### PR DESCRIPTION
## Description

Many of the packages contain broken links to their GitHub repositories, leading to a 404 error when accessed via npm or yarn.

https://github.com/user-attachments/assets/43459e70-5b91-485a-a4f6-d1d56c00eb0d