### PR TITLE
Add loom and wistia videos

### DIFF
--- a/packages/plugins/embed/src/providers/Loom.tsx
+++ b/packages/plugins/embed/src/providers/Loom.tsx
@@ -1,0 +1,38 @@
+import { useRef, useState } from 'react';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+import { ProviderRenderProps } from '../types';
+
+function Loom({ provider, attributes, children }: ProviderRenderProps) {
+  const loomRootRef = useRef(null);
+  const [isFrameLoaded, setFrameLoaded] = useState(false);
+
+  const { isIntersecting: isInViewport } = useIntersectionObserver(loomRootRef, {
+    freezeOnceVisible: true,
+    rootMargin: '50%',
+  });
+
+  const onRef = (node) => {
+    loomRootRef.current = node;
+    attributes.ref(node);
+  };
+
+  return (
+    <div {...attributes} ref={onRef} className="yoo-embed-relative" style={{ paddingBottom: '53.90625%' }}>
+      {isInViewport && (
+        <iframe
+          title="Loom Video Player"
+          src={`https://www.loom.com/embed/${provider.id}?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true`}
+          frameBorder="0"
+          allowFullScreen
+          webkitallowfullscreen="true"
+          mozallowfullscreen="true"
+          onLoad={() => setFrameLoaded(true)}
+          className="yoo-embed-absolute yoo-embed-top-0 yoo-embed-left-0 yoo-embed-w-full yoo-embed-h-full"
+        />
+      )}
+      {children}
+    </div>
+  );
+}
+
+export { Loom };

--- a/packages/plugins/embed/src/providers/Wistia.tsx
+++ b/packages/plugins/embed/src/providers/Wistia.tsx
@@ -1,0 +1,43 @@
+import { useRef, useState } from 'react';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+import { ProviderRenderProps } from '../types';
+
+function Wistia({ provider, attributes, children }: ProviderRenderProps) {
+  const wistiaRootRef = useRef(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const { isIntersecting: isInViewport } = useIntersectionObserver(wistiaRootRef, {
+    freezeOnceVisible: true,
+    rootMargin: '50%',
+  });
+
+  const onRef = (node) => {
+    wistiaRootRef.current = node;
+    attributes.ref(node);
+  };
+
+  return (
+    <div {...attributes} ref={onRef} className="yoo-embed-relative" style={{ paddingBottom: '56.25%' }}>
+      {isInViewport && (
+        <>
+          <script src={`https://fast.wistia.com/embed/medias/${provider.id}.jsonp`} async />
+          <script src="https://fast.wistia.com/assets/external/E-v1.js" async />
+          <div className="wistia_responsive_padding" style={{ padding: '56.25% 0 0 0', position: 'relative' }}>
+            <div
+              className="wistia_responsive_wrapper"
+              style={{ height: '100%', left: 0, position: 'absolute', top: 0, width: '100%' }}
+            >
+              <div
+                className={`wistia_embed wistia_async_${provider.id} videoFoam=true`}
+                style={{ height: '100%', position: 'relative', width: '100%' }}
+              />
+            </div>
+          </div>
+        </>
+      )}
+      {children}
+    </div>
+  );
+}
+
+export { Wistia };

--- a/packages/plugins/embed/src/types.ts
+++ b/packages/plugins/embed/src/types.ts
@@ -10,6 +10,8 @@ export type EmbedProviderTypes =
   | 'youtube'
   | 'vimeo'
   | 'dailymotion'
+  | 'wistia'
+  | 'loom'
   | 'twitter'
   | 'figma'
   | 'instagram'

--- a/packages/plugins/embed/src/ui/EmbedComponent.tsx
+++ b/packages/plugins/embed/src/ui/EmbedComponent.tsx
@@ -5,6 +5,8 @@ import Instagram from '../providers/Instagram';
 import Twitter from '../providers/Twitter';
 import { Vimeo } from '../providers/Vimeo';
 import { YouTube } from '../providers/Youtube';
+import { Loom } from '../providers/Loom';
+import { Wistia } from '../providers/Wistia';
 import { EmbedElementProps } from '../types';
 
 type EmbedComponentProps = Omit<EmbedElementProps, 'sizes'> & {

--- a/packages/plugins/embed/src/utils/providers.ts
+++ b/packages/plugins/embed/src/utils/providers.ts
@@ -24,6 +24,16 @@ export const getDailymotionId = (url: string) => {
   return null;
 };
 
+export const getWistiaId = (url: string) => {
+  const match = url.match(/(?:https?:\/\/)?(?:www\.)?wistia\.com\/medias\/(.+)/);
+  return match ? match[1] : null;
+};
+
+export const getLoomId = (url: string) => {
+  const match = url.match(/(?:https?:\/\/)?(?:www\.)?loom\.com\/share\/(.+)/);
+  return match ? match[1] : null;
+};
+
 export function getInstagramId(url: string) {
   const regex = /(?:https?:\/\/)?(?:www\.)?instagram\.com(?:\/p\/|\/reel\/|\/tv\/)([^\/?#&]+).*$/;
   const match = url.match(regex);
@@ -37,6 +47,10 @@ export function getProvider(url: string): EmbedProviderTypes | null {
     return 'vimeo';
   } else if (url.includes('dailymotion.com') || url.includes('dai.ly')) {
     return 'dailymotion';
+  } else if (url.includes('loom.com')) {
+    return 'loom';
+  } else if (url.includes('wistia.com')) {
+    return 'wistia';
   } else if (url.includes('twitter') || url.includes('https://x.com')) {
     return 'twitter';
   } else if (url.includes('figma')) {
@@ -70,6 +84,8 @@ export const ProviderGetters = {
   youtube: getYoutubeId,
   vimeo: getVimeoId,
   dailymotion: getDailymotionId,
+  wistia: getWistiaId,
+  loom: getLoomId,
   twitter: getTwitterEmbedId,
   figma: getFigmaUrl,
   instagram: getInstagramId,

--- a/packages/plugins/video/src/plugin/index.tsx
+++ b/packages/plugins/video/src/plugin/index.tsx
@@ -42,7 +42,7 @@ const Video = new YooptaPlugin<VideoElementMap, VideoPluginOptions>({
     onUpload: async () => Promise.resolve({ src: '' }),
     display: {
       title: 'Video',
-      description: 'Upload from device, embed from Youtube, Vimeo',
+      description: 'Upload from device, embed from Youtube, Vimeo, DailyMotion, Loom, Wistia',
     },
   },
   commands: VideoCommands,

--- a/packages/plugins/video/src/types.ts
+++ b/packages/plugins/video/src/types.ts
@@ -12,7 +12,7 @@ export type VideoElementSettings = {
   autoPlay?: boolean;
 };
 
-export type VideoProviderTypes = 'youtube' | 'vimeo' | 'dailymotion' | string | null;
+export type VideoProviderTypes = 'youtube' | 'vimeo' | 'dailymotion' | 'loom' | 'wistia' | string | null;
 export type VideoProvider = {
   type: VideoProviderTypes;
   id: string;

--- a/packages/plugins/video/src/ui/EmbedUploader.tsx
+++ b/packages/plugins/video/src/ui/EmbedUploader.tsx
@@ -15,7 +15,7 @@ const EmbedUploader = ({ blockId, onClose }) => {
     const providerType = getProvider(value);
     const videoId = providerType ? ProviderGetters[providerType]?.(value) : null;
 
-    if (!providerType || !videoId) return console.warn('Unsopperted video provider or video id is not found.');
+    if (!providerType || !videoId) return console.warn('Unsupported video provider or video id is not found.');
 
     Elements.updateElement<VideoPluginElements, VideoElementProps>(editor, blockId, {
       type: 'video',

--- a/packages/plugins/video/src/ui/LoomPlayer.tsx
+++ b/packages/plugins/video/src/ui/LoomPlayer.tsx
@@ -1,0 +1,66 @@
+import { useRef, useState, useEffect } from 'react';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+
+function LoomPlayer({ videoId, children, attributes, width, height, ...other }) {
+  const loomRootRef = useRef(null);
+  const [isFrameLoaded, setFrameLoaded] = useState(false);
+  const [iframeKey, setIframeKey] = useState(0); // Add key to force re-render
+
+  const { isIntersecting: isInViewport } = useIntersectionObserver(loomRootRef, {
+    freezeOnceVisible: true,
+    rootMargin: '50%',
+  });
+
+  const onRef = (el) => {
+    loomRootRef.current = el;
+    attributes.ref(el);
+  };
+
+  // Force iframe reload when it becomes visible
+  useEffect(() => {
+    if (isInViewport) {
+      setIframeKey((prev) => prev + 1);
+    }
+  }, [isInViewport]);
+
+  return (
+    <div {...attributes} ref={onRef} className="yoo-video-relative" style={{ width, height }}>
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        {isInViewport && (
+          <iframe
+            key={iframeKey}
+            title="Loom Video Player"
+            src={`https://www.loom.com/embed/${videoId}?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true`}
+            frameBorder="0"
+            webkitallowfullscreen="true"
+            mozallowfullscreen="true"
+            allowFullScreen
+            onLoad={() => {
+              console.log('Loom iframe loaded');
+              setFrameLoaded(true);
+            }}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              border: 'none',
+              borderRadius: '4px',
+            }}
+            {...other}
+          />
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default LoomPlayer;

--- a/packages/plugins/video/src/ui/VideoComponent.tsx
+++ b/packages/plugins/video/src/ui/VideoComponent.tsx
@@ -4,6 +4,8 @@ import { VideoElementProps } from '../types';
 import DailyMotion from './DailyMotionPlayer';
 import VimeoPlayer from './VimeoPlayer';
 import YouTubePlayer from './YoutubePlayer';
+import LoomPlayer from './LoomPlayer';
+import WistiaPlayer from './WistiaPlayer';
 
 type VideoComponentProps = Omit<VideoElementProps, 'sizes'> & {
   width: number | string;
@@ -14,6 +16,8 @@ const PROVIDERS = {
   vimeo: VimeoPlayer,
   youtube: YouTubePlayer,
   dailymotion: DailyMotion,
+  loom: LoomPlayer,
+  wistia: WistiaPlayer,
 };
 
 const VideoComponent = ({

--- a/packages/plugins/video/src/ui/WistiaPlayer.tsx
+++ b/packages/plugins/video/src/ui/WistiaPlayer.tsx
@@ -1,0 +1,52 @@
+import { useRef, useState } from 'react';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+
+function WistiaPlayer({ videoId, children, attributes, width, height, ...other }) {
+  const wistiaRootRef = useRef(null);
+  const [isFrameLoaded, setFrameLoaded] = useState(false);
+
+  const { isIntersecting: isInViewport } = useIntersectionObserver(wistiaRootRef, {
+    freezeOnceVisible: true,
+    rootMargin: '50%',
+  });
+
+  const onRef = (el) => {
+    wistiaRootRef.current = el;
+    attributes.ref(el);
+  };
+
+  return (
+    <div {...attributes} ref={onRef} className="yoo-video-relative" style={{ width, height }}>
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        {isInViewport && (
+          <iframe
+            src={`https://fast.wistia.net/embed/iframe/${videoId}?videoFoam=true`}
+            title="Wistia Video Player"
+            frameBorder="0"
+            allowFullScreen
+            onLoad={() => setFrameLoaded(true)}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              border: 'none',
+              borderRadius: '4px',
+            }}
+            {...other}
+          />
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default WistiaPlayer;

--- a/packages/plugins/video/src/utils/providers.ts
+++ b/packages/plugins/video/src/utils/providers.ts
@@ -24,6 +24,33 @@ export const getDailymotionId = (url: string) => {
   return null;
 };
 
+export const getWistiaId = (url: string) => {
+  try {
+    // Handle iframe embed URLs
+    const iframeMatch = url.match(/(?:https?:\/\/)?(?:fast\.)?wistia\.(?:com|net)\/embed\/iframe\/([a-zA-Z0-9]+)/);
+    if (iframeMatch) return iframeMatch[1];
+
+    // Handle medias URLs
+    const mediasMatch = url.match(/(?:https?:\/\/)?(?:www\.)?wistia\.com\/medias\/([a-zA-Z0-9]+)/);
+    if (mediasMatch) return mediasMatch[1];
+
+    return null;
+  } catch (error) {
+    console.error('Error extracting Wistia ID:', error);
+    return null;
+  }
+};
+
+export const getLoomId = (url: string) => {
+  try {
+    const match = url.match(/(?:https?:\/\/)?(?:www\.)?loom\.com\/share\/([a-zA-Z0-9]+)/);
+    return match ? match[1] : null;
+  } catch (error) {
+    console.error('Error extracting Loom ID:', error);
+    return null;
+  }
+};
+
 export function getProvider(url: string): VideoProviderTypes | null {
   if (url.includes('youtube.com') || url.includes('youtu.be')) {
     return 'youtube';
@@ -31,6 +58,10 @@ export function getProvider(url: string): VideoProviderTypes | null {
     return 'vimeo';
   } else if (url.includes('dailymotion.com') || url.includes('dai.ly')) {
     return 'dailymotion';
+  } else if (url.includes('loom.com')) {
+    return 'loom';
+  } else if (url.includes('wistia.com')) {
+    return 'wistia';
   }
   // } else if (url.includes('twitch.tv')) {
   //   return 'Twitch';
@@ -44,4 +75,6 @@ export const ProviderGetters = {
   youtube: getYoutubeId,
   vimeo: getVimeoId,
   dailymotion: getDailymotionId,
+  loom: getLoomId,
+  wistia: getWistiaId,
 };


### PR DESCRIPTION
## Description

Added the ability to add Loom & Wistia videos in the Video plugin. Note that I'm not used to Typescrpt at all, so I might need some help with this if you see issues.

I also fixed a typo and added more video types to this element:
![CleanShot 2024-11-11 at 17 16 59](https://github.com/user-attachments/assets/9c4e6b85-ef21-4672-9ded-5de03f378c2e)
"Upload from device, embed from Youtube, Vimeo, DailyMotion, Loom, Wistia"

Fixes # (issue)

## Type of change

Please tick the relevant option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings
